### PR TITLE
refactor(symfony-app.docker-hybrid:makefile): change setup/halt/destroy tasks to install/stop/down

### DIFF
--- a/symfony-app.docker-hybrid/.manala/Makefile.tmpl
+++ b/symfony-app.docker-hybrid/.manala/Makefile.tmpl
@@ -26,64 +26,68 @@ php := $(symfony) php
 composer := $(symfony) composer
 
 APP_DOMAINS := {{ .Vars.system.app_name }}
+MANDATORY_CONTAINERS := {{- if $has_mysql }} database{{ end }}
+                        {{- if $has_redis }} redis{{ end }}
+                        {{- if $has_redis }} mailcatcher{{ end }}
+                        {{- if $has_rabbitmq }} rabbitmq{{ end }}
 
 HELP += $(call help_section, Environment)
 
-HELP += $(call help,setup,             Setup the development environment)
-setup: setup-symfony
-	$(MAKE) up
-	$(setup)
-	@echo
-	@$(call message_success, The development environment has been successfully set up.)
-	@echo
-
-HELP += $(call help,setup@integration, Setup the integration environment)
-setup@integration: export APP_ENV=test
-setup@integration: setup-symfony@integration
-	$(MAKE) _up
-	$(setup_integration)
-	@echo
-	@$(call message_success, The integration environment has been successfully set up.)
-	@echo
-
-setup-symfony:
+HELP += $(call help,install,             Install the environment)
+install:
 	$(symfony) server:ca:install
 	$(symfony) proxy:start
 	echo $(APP_DOMAINS) | xargs $(symfony) proxy:domain:attach
 
-setup-symfony@integration:
+	$(MAKE) up
+	$(install)
+	@echo
+	@$(call message_success, The environment has been successfully installed.)
+	@echo
+
+HELP += $(call help,install@integration, Install the environment (integration))
+install@integration: export APP_ENV=test
+install@integration:
 	$(symfony) server:ca:install
+	$(MAKE) up
+	$(install_integration)
+	@echo
+	@$(call message_success, The integration environment has been successfully installed.)
+	@echo
 
 _up:
-	$(dc) up --detach
-	{{- if $has_mysql }} database{{ end }}
-	{{- if $has_redis }} redis{{ end }}
-	{{- if $has_redis }} mailcatcher{{ end }}
-	{{- if $has_rabbitmq }} rabbitmq{{ end }}
+	$(dc) up --detach $(MANDATORY_CONTAINERS)
 
+_start:
+	$(dc) start $(MANDATORY_CONTAINERS)
+
+_wait_for_database:
 	{{ if $has_mysql -}}
 	@$(call message_warning, Waiting for the database to be ready...)
 	@until docker inspect -f {{ "{{.State.Health.Status}}" }} `$(dc) ps -q database` | grep -q "healthy"; do \
-      $(call message_warning, Waiting...); \
-      sleep 1; \
+	  $(call message_warning, Waiting...); \
+	  sleep 1; \
 	done
 	@$(call message_success, The database is ready!)
 	{{- end }}
 
-HELP += $(call help,up,                Start the development environment)
-up:
-	$(MAKE) _up
-	$(symfony) proxy:start
+_post_start_success:
 	@echo
 	@$(call message_success, You can now run the Symfony server)
 	@echo
 
-HELP += $(call help,halt,              Stop the development environment)
-halt:
+HELP += $(call help,up,                  Update and start the environment)
+up: _up _wait_for_database _post_start_success
+
+HELP += $(call help,start,               Start the environment)
+start: _start _wait_for_database _post_start_success
+
+HELP += $(call help,stop,                Stop the environment)
+stop:
 	$(dc) stop
 
-HELP += $(call help,destroy,           Destroy the development environment)
-destroy: halt
+HELP += $(call help,down,                Stop and remove the environment)
+down: stop
 	$(dc) down --volumes
 	@echo
 	@$(call message_error, ALL CONTAINERS HAVE BEEN DESTROYED)
@@ -92,7 +96,7 @@ destroy: halt
 HELP += $(call help_section, Development tools)
 
 {{ if $has_mysql -}}
-HELP += $(call help,run-phpmyadmin,    Start a PhpMyAdmin web interface)
+HELP += $(call help,run-phpmyadmin,    Start a web interface for PhpMyAdmin)
 run-phpmyadmin:
 	$(dc) up --detach phpmyadmin
 	@echo
@@ -101,7 +105,7 @@ run-phpmyadmin:
 {{- end }}
 
 {{ if $has_redis -}}
-HELP += $(call help,run-phpredisadmin, Start a PhpRedisAdmin web interface)
+HELP += $(call help,run-phpredisadmin, Start a web interface for PhpRedisAdmin)
 run-phpredisadmin:
 	$(dc) up --detach phpredisadmin
 	@echo
@@ -109,13 +113,13 @@ run-phpredisadmin:
 	@echo{{- end }}
 
 {{ if $has_mailcatcher -}}
-HELP += $(call help,open-mailcatcher,  Open the MailCatcher web interface)
+HELP += $(call help,open-mailcatcher,  Open the web interface for MailCatcher)
 open-mailcatcher:
 	$(symfony) open:local:webmail
 {{- end }}
 
 {{ if $has_rabbitmq -}}
-HELP += $(call help,open-rabbitmq,     Open the RabbitMQ web interface)
+HELP += $(call help,open-rabbitmq,     Open the web interface for RabbitMQ)
 open-rabbitmq:
 	$(symfony) open:local:rabbitmq
 	@$(call message_success, Use \"guest\" as username and \"guest\" as password.)

--- a/symfony-app.docker-hybrid/README.md
+++ b/symfony-app.docker-hybrid/README.md
@@ -55,15 +55,15 @@ Edit the `Makefile` at the root directory of your project and add the following 
 ```makefile
 -include .manala/Makefile
 
-# This function will be called at the end of "make setup"
-define setup
+# This function will be called at the end of "make install"
+define install
 	# For example:
 	# $(MAKE) install-app
 	# $(MAKE) init-db@test
 endef
 
-# This function will be called at the end of "make setup@integration"
-define setup_integration
+# This function will be called at the end of "make install@integration"
+define install_integration
 	# For example:
 	# $(MAKE) install-app@integration
 endef
@@ -86,37 +86,47 @@ Help:
   help This help 	
 
 Environment:   
-  setup              Setup the development environment   
-  setup@integration  Setup the integration environment   
-  up                 Start the development environment   
-  halt               Stop the development environment   
-  destroy            Destroy the development environment 	
+  install              Install the environment   
+  install@integration  Install the environment (integration)   
+  up                   Update and start the environment   
+  start                Start the environment   
+  stop                 Stop the environment   
+  down                 Stop and remove the environment 	
+
+Development tools:   
+  run-phpmyadmin     Start a web interface for PhpMyAdmin   
+  run-phpredisadmin  Start a web interface for PhpRedisAdmin   
+  open-mailcatcher   Open the web interface for MailCatcher   
+  open-rabbitmq      Open the web interface for RabbitMQ 	
 
 Project:
-  install-app:             Install application
-  install-app@integration: Install application in integration environment
 ```
 
 ## Docker interaction
 
 Initialise Docker Compose containers and your app:
 ```bash
-make setup
+make install
 ```
 
-Start Docker Compose containers:
+Update and start Docker Compose containers:
 ```bash
 make up
 ```
 
+Start Docker Compose containers:
+```bash
+make start
+```
+
 Stop Docker Compose containers:
 ```bash
-make halt
+make stop
 ```
 
 Stop and remove Docker Compose containers:
 ```shell
-make destroy
+make down
 ```
 
 ## System
@@ -241,14 +251,14 @@ Add in your `Makefile`:
 ```makefile
 # ...
 
-# This function will be called during "make setup"
-define setup
+# This function will be called during "make install"
+define install
     $(MAKE) install-app
     $(MAKE) init-db@test
 endef
 
-# This function will be called during "make setup@integration"
-define setup_integration
+# This function will be called during "make install@integration"
+define install_integration
     $(MAKE) install-app@integration
 endef
 
@@ -304,6 +314,8 @@ reload-db@test:
 
 - run `make run-phpmyadmin` to start a local [PhpMyAdmin](https://github.com/phpmyadmin/phpmyadmin) instance
 - run `make run-phpredisadmin` to start a local [PhpRedisAdmin](https://github.com/erikdubbelboer/phpRedisAdmin) instance.
+- run `make open-mailcatcher` to open a local [MailCatcher Web UI](https://mailcatcher.me).
+- run `make open-rabbitmq` to open a local [RabbitMQ Management Web UI](https://www.rabbitmq.com/management.html).
 
 ### Installing PHP on your machine
 
@@ -369,4 +381,6 @@ plugins=(... nvm)
 #[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
 ```
 
-`yarn` can be installed through `npm install --global yarn`.
+### Yarn
+
+The [package manager `yarn`](https://yarnpkg.com/) can be installed with `npm install --global yarn`.


### PR DESCRIPTION
Afin d'être plus en raccord avec les commandes utilisées par l'ensemble de l'équipe sur le projet Wamiz Inter. 

Les tâches setup/halt/destroy sont des "relicats" provenant d'yProx lorsqu'on utilisait Vagrant (`vagrant halt`, `vagrant destroy` ...), qui avaient également été préservés pour ne pas déstabiliser l'équipe yProx.

Aussi, ajout de la commande `make start` (correspondant à `docker-compose start`) 