### PR TITLE
feat(symfony-app.docker-hybrid): add support for Docker Compose v2

### DIFF
--- a/symfony-app.docker-hybrid/.manala/Makefile.tmpl
+++ b/symfony-app.docker-hybrid/.manala/Makefile.tmpl
@@ -20,7 +20,7 @@ include $(_ROOT_DIR)/.manala/make/git.mk
 user := $(shell id -u)
 group := $(shell id -g)
 
-dc := USER_ID=$(user) GROUP_ID=$(group) docker-compose
+dc := USER_ID=$(user) GROUP_ID=$(group) $(shell docker compose > /dev/null 2>&1 && echo 'docker compose' || echo 'docker-compose')
 symfony := symfony
 php := $(symfony) php
 composer := $(symfony) composer

--- a/symfony-app.docker-hybrid/.manala/Makefile.tmpl
+++ b/symfony-app.docker-hybrid/.manala/Makefile.tmpl
@@ -25,7 +25,8 @@ symfony := symfony
 php := $(symfony) php
 composer := $(symfony) composer
 
-APP_DOMAINS := {{ .Vars.system.app_name }}
+APP_NAME := {{ .Vars.system.app_name }}
+APP_DOMAINS := $(APP_NAME)
 MANDATORY_CONTAINERS := {{- if $has_mariadb }} database{{ end }}
                         {{- if $has_redis }} redis{{ end }}
                         {{- if $has_redis }} mailcatcher{{ end }}

--- a/symfony-app.docker-hybrid/README.md
+++ b/symfony-app.docker-hybrid/README.md
@@ -7,11 +7,10 @@ A [Manala recipe](https://github.com/manala/manala-recipes) for projects using t
 ## Requirements
 
 * [manala](https://manala.github.io/manala/)
-* Docker Engine: 
-    * [Debian](https://hub.docker.com/editions/community/docker-ce-server-debian)
+* Docker Desktop >= 3.4.0: 
+    * [Debian](https://hub.docker.com/editions/community/docker-ce-server-debian), with [Docker Compose v2 plugin](https://docs.docker.com/compose/cli-command/#install-on-linux)
     * [macOS](https://hub.docker.com/editions/community/docker-ce-desktop-mac)
     * [Windows](https://hub.docker.com/editions/community/docker-ce-desktop-windows)
-* [Docker Compose](https://docs.docker.com/compose/install/)
 * [Symfony CLI](https://symfony.com/doc/current/setup/symfony_server.html) (with [local proxy support](https://symfony.com/doc/current/setup/symfony_server.html#setting-up-the-local-proxy), see [specific steps for Windows and WSL](https://github.com/wamiz/manala-recipes/issues/6))
 * PHP and Node.js must be installed by yourself on your machine, see:
     * [Installing PHP on your machine](#installing-php-on-your-machine)


### PR DESCRIPTION
[Docker Compose v2](https://docs.docker.com/compose/cli-command/) est la nouvelle version de [`docker-compose`](https://docs.docker.com/compose/) directement intégrée au binaire Docker via `docker compose` (sans le `-`) 

Il se trouve qu'avec Docker Desktop (Mac et Windows), Docker Compose v2 est activé par défaut et c'est ce qui a entraîné la prise de tête de @jlopinto :stuck_out_tongue_closed_eyes: 

La recipe n'étant pas compatible avec Docker Compose v2, c'est désormais chose faite. 

Si la commande `docker compose` ne retourne pas d'erreur, on l'utilise, sinon on utilise `docker-compose`.

J'en profite également pour créer une variable `APP_NAME`.