### PR TITLE
fix(symfony-app.docker-hybrid:docker): pass /dev/null as env-file

### DIFF
--- a/symfony-app.docker-hybrid/.manala/Makefile.tmpl
+++ b/symfony-app.docker-hybrid/.manala/Makefile.tmpl
@@ -19,7 +19,7 @@ include $(_ROOT_DIR)/.manala/make/git.mk
 user := $(shell id -u)
 group := $(shell id -g)
 
-dc := USER_ID=$(user) GROUP_ID=$(group) $(shell docker compose > /dev/null 2>&1 && echo 'docker compose' || echo 'docker-compose')
+dc := USER_ID=$(user) GROUP_ID=$(group) $(shell docker compose --env-file /dev/null > /dev/null 2>&1 && echo 'docker compose --env-file /dev/null' || echo 'docker-compose --env-file /dev/null')
 symfony := symfony
 php := $(symfony) php
 composer := $(symfony) composer


### PR DESCRIPTION
Docker compose n'arrive pas à lire correctement notre `.env` : 
![image](https://user-images.githubusercontent.com/2103975/184103483-0ffc4be9-5409-4be8-9d4a-75d4b6c02f67.png)

J'avais déjà eu l'erreur que j'avais pu _corriger_ en ajoutant des `"` sur `SOURCE_VERSION="$(git rev-parse HEAD)"`, mais depuis que j'ai mis à jour Docker/Docker compose, ça ne passe plus 😬 


Avec ce fix, le `.env` n'est plus lu : 
<img width="1486" alt="image" src="https://user-images.githubusercontent.com/2103975/184103522-78ff1efe-6a30-47d6-b27b-93c129724fc7.png">
