### PR TITLE
Typo in pcre2 symbolic link creation command

### DIFF
--- a/symfony-app.docker-hybrid/README.md
+++ b/symfony-app.docker-hybrid/README.md
@@ -348,7 +348,7 @@ symfony pecl install {redis,apcu,imagick}
 > **Warning**
 > You may get an error regarding `pcre2.h`. To solve this issue, you have to create a symbolic link: 
 > ```shell
-> ln -s /opt/homebrew/Cellar/pcre2/$(brew list --versions pcre2 | cut -d ' ' -f2)/include/pcre2.h /opt/homebrew/Cellar/php@8.1/$(brew list --versions php@8.1 | cut - d ' ' -f2)/include/php/ext/pcre/pcre2.h
+> ln -s /opt/homebrew/Cellar/pcre2/$(brew list --versions pcre2 | cut -d ' ' -f2)/include/pcre2.h /opt/homebrew/Cellar/php@8.1/$(brew list --versions php@8.1 | cut -d ' ' -f2)/include/php/ext/pcre/pcre2.h
 > ```
 
 Finally, you can add PHP binaries to your path by adding the following line in your `.zshrc` or `.bashrc`: 


### PR DESCRIPTION
Fix d'une typo dans la commande