### PR TITLE
feat(symfony-app.docker-hybrid): configurable database host port

### DIFF
--- a/symfony-app.docker-hybrid/.manala.yaml
+++ b/symfony-app.docker-hybrid/.manala.yaml
@@ -27,6 +27,9 @@ system:
         # @option {"label": "MySQL version"}
         # @schema {"type": ["string", "null"], "pattern": "^[0-9]+([.][0-9]+){0,2}$"}
         version: ~
+        # @option {"label": "MySQL host port (publishes <port>:3306; null = dynamic host port)"}
+        # @schema {"type": ["integer", "null"]}
+        port: ~
         # @schema {"type": ["string", "null"]}
         init: ~
         # @schema {"type": ["string", "null"]}
@@ -35,6 +38,9 @@ system:
         # @option {"label": "MariaDB version"}
         # @schema {"enum": [null, 10.11, 10.6, 10.5, 10.4, 10.3, 10.2, 10.1]}
         version: ~
+        # @option {"label": "MariaDB host port (publishes <port>:3306; null = dynamic host port)"}
+        # @schema {"type": ["integer", "null"]}
+        port: ~
         # @schema {"type": ["string", "null"]}
         init: ~
         # @schema {"type": ["string", "null"]}

--- a/symfony-app.docker-hybrid/docker-compose.override.yaml.tmpl
+++ b/symfony-app.docker-hybrid/docker-compose.override.yaml.tmpl
@@ -4,8 +4,9 @@
 
 {{- $has_database := or (.Vars.system.mysql.version) (.Vars.system.mariadb.version) }}
 {{- if $has_database }}
+{{- $port := or .Vars.system.mysql.port .Vars.system.mariadb.port }}
 
 services:
   database:
-    ports: [3306]
+    ports: [{{ if $port }}'{{ $port }}:3306'{{ else }}3306{{ end }}]
 {{- end }}


### PR DESCRIPTION
## Why

The generated `docker-compose.override.yaml` publishes the DB with `ports: [3306]` — short syntax, so Docker assigns a **random** host port. Projects that hardcode `127.0.0.1:3306` in `DATABASE_URL` break after every `manala up` until the dynamic port is rediscovered (flagged by Codex on a consuming project).

## What

Add an optional `system.mysql.port` / `system.mariadb.port` (`integer | null`):

```yaml
{{- $port := or .Vars.system.mysql.port .Vars.system.mariadb.port }}
services:
  database:
    ports: [{{ if $port }}'{{ $port }}:3306'{{ else }}3306{{ end }}]
```

- **Set** (e.g. `port: 3306`) → publishes `3306:3306`, a stable `localhost:3306`.
- **Null (default)** → keeps the dynamic host port — **existing projects unchanged** (and avoids port clashes when running several projects at once).

Backward compatible: projects that don't define `port` resolve it to `null` via the recipe default and get the current behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)